### PR TITLE
Fix Try It! button in menu

### DIFF
--- a/ontology_workshop/templates/default.html.j2
+++ b/ontology_workshop/templates/default.html.j2
@@ -36,7 +36,7 @@
                 <a href="../contributors">Contributors</a>
                 <a href="https://github.com/Materials-Consortia/" target="_blank">GitHub</a>
                 <a href="https://matsci.org/c/optimade/" target="_blank">Forum</a>
-                <span class="special_menu"><a href="clients">Try It!</a></span>
+                <span class="special_menu"><a href="../clients">Try It!</a></span>
        	    </div>
         </header>
     </div>


### PR DESCRIPTION
Point it to the relative URL in the parent, i.e., remove `/ontology-workshop/` from the URL.