### PR TITLE
Add presentations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
       COMMIT_AUTHOR_EMAIL: dev@optimade.org
 
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -14,10 +14,10 @@ jobs:
       COMMIT_AUTHOR_EMAIL: dev@optimade.org
 
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 

--- a/omdi2021/content.md
+++ b/omdi2021/content.md
@@ -1,5 +1,7 @@
 # OMDI2021
 
+<!-- markdownlint-disable MD033 -->
+
 ***Workshop on Ontologies for Materials-Databases Interoperability 2021***
 
 <div style="border:5px double #00acd9;padding:5px;"><strong>Place</strong>: Linköping University, Sweden & Digital participation<br/><strong>Time</strong>: October 5-7, 2021</div>

--- a/omdi2021/content.md
+++ b/omdi2021/content.md
@@ -85,6 +85,18 @@ The OMDI2021 workshop aims to leverage the part of that community interested in 
 **Gareth Conduit**, University of Cambridge, UK  
 **Gian-Marco Rignanese**, UCLouvain, Belgium
 
+### Recorded presentations
+
+*Recordings of the presentations will be found here.*
+
+LICENSE: CC-BY-4.0
+
+### Presentation slides
+
+*Presentation slides will be available here.*
+
+LICENSE: CC-BY-4.0
+
 ## <a name="registration" class="mdheader"></a> Registration
 
 The registration form has now closed.

--- a/omdi2021/content.md
+++ b/omdi2021/content.md
@@ -87,7 +87,9 @@ The OMDI2021 workshop aims to leverage the part of that community interested in 
 
 ## <a name="registration" class="mdheader"></a> Registration
 
-The registration form has now closed. Late registation is possible via email. Please email **omdi2021[at]groups.liu.se** stating your name, affiliation and country, and we will provide you with the participation links.
+The registration form has now closed.
+Late registation is possible via email.
+Please email **omdi2021[at]groups.liu.se** stating your name, affiliation and country, and we will provide you with the participation links.
 
 ## <a name="program" class="mdheader"></a> Program
 


### PR DESCRIPTION
This mainly adds the recordings as well as links to or directly provides the presentation slides/material.

Minor updates:
- Use vMAJOR for GH Actions.
- One line per one sentence syntax throughout `content.md`.
- Disable `markdownlint` warnings concerning use of raw HTML.
- Remove redundant file in "root" of assets folder.